### PR TITLE
Added kvh 1775 to hyq green

### DIFF
--- a/robots/hyq.urdf.xacro
+++ b/robots/hyq.urdf.xacro
@@ -94,20 +94,23 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 	<!-- IMU trunk -->
 	<xacro:microstrain_3dmgx425_imu
 		parent="trunk"
-		imu_name="imu"
+		imu_name="trunk_imu"
 		imu_topic="trunk_imu_1/data"
 		update_rate="250">
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>
 	</xacro:microstrain_3dmgx425_imu>
 
     <!-- IMU trunk -->
-    <xacro:kvh_1775_imu
+<!-- TODO We have to substitute the microstrain IMU with this one. Note that the imu_name has to be
+trunk_imu because the DLS HW interfaces hardcoded that name 
+    	<xacro:kvh_1775_imu
         parent="trunk"
-        imu_name="kvh_imu"
+        imu_name="trunk_imu"
         imu_topic="trunk_imu_2/data"
         update_rate="250">
         <origin xyz="0.352845 0.0029 0.0503678" rpy="0 ${-PI} 0"/>
     </xacro:kvh_1775_imu>
+-->
 
 	<!-- Hokuyo -->
 	<xacro:hokuyo_laser

--- a/robots/hyq.urdf.xacro
+++ b/robots/hyq.urdf.xacro
@@ -95,16 +95,8 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 	<xacro:microstrain_3dmgx425_imu
 		parent="trunk"
 		imu_name="imu"
-		imu_topic="trunk_imu/data"
-		update_rate="250"
-		rate_mean="0"
-		rate_stddev="2e-4"
-		rate_bias_mean="0.00087"
-		rate_bias_stddev="0.0000008"
-		accel_mean="0"
-		accel_stddev="1.7e-2"
-		accel_bias_mean="0.002"
-		accel_bias_stddev="0.001">
+		imu_topic="trunk_imu_1/data"
+		update_rate="250">
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>
 	</xacro:microstrain_3dmgx425_imu>
 
@@ -112,18 +104,8 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
     <xacro:kvh_1775_imu
         parent="trunk"
         imu_name="kvh_imu"
-        imu_topic="trunk_imu/data"
-        update_rate="250"
-        rate_mean="0"
-        rate_stddev="2e-4"
-        rate_bias_mean="0.00087"
-        rate_bias_stddev="0.0000008"
-        accel_mean="0"
-        accel_stddev="1.7e-2"
-        accel_bias_mean="0.002"
-        accel_bias_stddev="0.001">
-        <!--origin xyz="0.331545 0.000 0.0887678" rpy="0 0 0"/-->
-        <!--origin xyz="0.310245 0.0029 0.1271678" rpy="0 ${-PI} 0"/-->
+        imu_topic="trunk_imu_2/data"
+        update_rate="250">
         <origin xyz="0.352845 0.0029 0.0503678" rpy="0 ${-PI} 0"/>
     </xacro:kvh_1775_imu>
 

--- a/robots/hyq.urdf.xacro
+++ b/robots/hyq.urdf.xacro
@@ -17,6 +17,7 @@
 
 	<!-- HyQ sensors -->
 	<xacro:include filename="$(find sensors_description)/urdfs/sensors/microstrain_3dmgx425_imu.urdf.xacro"/>
+    <xacro:include filename="$(find sensors_description)/urdfs/sensors/kvh_1775_imu.urdf.xacro"/>
 	<xacro:include filename="$(find sensors_description)/urdfs/sensors/asus_xtion.urdf.xacro"/>
 	<!-- Velodyne disabled because it takes too long to load-up -->
 	<!-- <xacro:include filename="$(find sensors_description)/urdfs/sensors/velodyne.urdf.xacro"/> -->
@@ -107,6 +108,25 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>
 	</xacro:microstrain_3dmgx425_imu>
 
+    <!-- IMU trunk -->
+    <xacro:kvh_1775_imu
+        parent="trunk"
+        imu_name="kvh_imu"
+        imu_topic="trunk_imu/data"
+        update_rate="250"
+        rate_mean="0"
+        rate_stddev="2e-4"
+        rate_bias_mean="0.00087"
+        rate_bias_stddev="0.0000008"
+        accel_mean="0"
+        accel_stddev="1.7e-2"
+        accel_bias_mean="0.002"
+        accel_bias_stddev="0.001">
+        <!--origin xyz="0.331545 0.000 0.0887678" rpy="0 0 0"/-->
+        <!--origin xyz="0.310245 0.0029 0.1271678" rpy="0 ${-PI} 0"/-->
+        <origin xyz="0.352845 0.0029 0.0503678" rpy="0 ${-PI} 0"/>
+    </xacro:kvh_1775_imu>
+
 	<!-- Hokuyo -->
 	<xacro:hokuyo_laser
 		name="laser"
@@ -116,7 +136,7 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 		min_angle="-5"
 		max_angle="5"
 		range="4.0">
-	<origin xyz="0.475 0.0 -0.08823" rpy="3.14 0.0 0"/>
+    <origin xyz="0.475 0.0 -0.08823" rpy="${PI} 0.0 0"/>
 	</xacro:hokuyo_laser>
 
     <xacro:multisense_sl parent="trunk" prefix="hyq">
@@ -132,3 +152,4 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 	</xacro:asus_xtion_camera>
 
 </robot>
+

--- a/robots/hyq_model.urdf.xacro
+++ b/robots/hyq_model.urdf.xacro
@@ -76,7 +76,7 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 	<!-- IMU trunk -->
 	<xacro:microstrain_3dmgx425_imu
 		parent="trunk"
-		imu_name="imu"
+		imu_name="trunk_imu"
 		imu_topic="trunk_imu/data"
 		update_rate="250">
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>

--- a/robots/hyq_model.urdf.xacro
+++ b/robots/hyq_model.urdf.xacro
@@ -78,15 +78,7 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 		parent="trunk"
 		imu_name="imu"
 		imu_topic="trunk_imu/data"
-		update_rate="250"
-		rate_mean="0"
-		rate_stddev="2e-4"
-		rate_bias_mean="0.00087"
-		rate_bias_stddev="0.0000008"
-		accel_mean="0"
-		accel_stddev="1.7e-2"
-		accel_bias_mean="0.002"
-		accel_bias_stddev="0.001">
+		update_rate="250">
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>
 	</xacro:microstrain_3dmgx425_imu>
 

--- a/robots/hyq_no_sensors.urdf.xacro
+++ b/robots/hyq_no_sensors.urdf.xacro
@@ -86,15 +86,7 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 		parent="trunk"
 		imu_name="imu"
 		imu_topic="trunk_imu/data"
-		update_rate="250"
-		rate_mean="0"
-		rate_stddev="2e-4"
-		rate_bias_mean="0.00087"
-		rate_bias_stddev="0.0000008"
-		accel_mean="0"
-		accel_stddev="1.7e-2"
-		accel_bias_mean="0.002"
-		accel_bias_stddev="0.001">
+		update_rate="250">
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>
 	</xacro:microstrain_3dmgx425_imu>
 

--- a/robots/hyq_no_sensors.urdf.xacro
+++ b/robots/hyq_no_sensors.urdf.xacro
@@ -84,7 +84,7 @@ is the world frame). For more, see http://www.ros.org/wiki/xacro -->
 	<!-- IMU trunk -->
 	<xacro:microstrain_3dmgx425_imu
 		parent="trunk"
-		imu_name="imu"
+		imu_name="trunk_imu"
 		imu_topic="trunk_imu/data"
 		update_rate="250">
 		<origin xyz="0.290 0.000 0.0999214" rpy="0 ${-PI} 0"/>


### PR DESCRIPTION
I've added the KVH to hyq-green. You need to take it from the other pull request on sensor_description.

NOTE: I'm assuming a frame of reference aligned with the connector, and not with the original axis of the KVH, for convenience.